### PR TITLE
[BUG] Poll when shutdown

### DIFF
--- a/duetector/static/config.toml
+++ b/duetector/static/config.toml
@@ -100,6 +100,7 @@ max_workers = 10
 
 [monitor.bcc.poller]
 interval_ms = 500
+call_when_shutdown = true
 
 [monitor.sh]
 disabled = false
@@ -111,6 +112,7 @@ max_workers = 10
 
 [monitor.sh.poller]
 interval_ms = 500
+call_when_shutdown = true
 
 [server]
 token = ""

--- a/duetector/tools/poller.py
+++ b/duetector/tools/poller.py
@@ -56,6 +56,8 @@ class Poller(Configuable):
             while not self.shutdown_event.is_set():
                 func(*args, **kwargs)
                 self.shutdown_event.wait(timeout=self.interval_ms / 1000)
+            # call func one last time before exit
+            func(*args, **kwargs)
 
         self._thread = threading.Thread(target=_poll)
         self.shutdown_event.clear()

--- a/duetector/tools/poller.py
+++ b/duetector/tools/poller.py
@@ -20,6 +20,7 @@ class Poller(Configuable):
 
     default_config = {
         "interval_ms": 500,
+        "call_when_shutdown": True,
     }
     """
     Default config for this poller.
@@ -42,6 +43,13 @@ class Poller(Configuable):
         """
         return self.config.interval_ms
 
+    @property
+    def call_when_shutdown(self):
+        """
+        Whether to call ``func`` when shutdown
+        """
+        return self.config.call_when_shutdown
+
     def start(self, func, *args, **kwargs):
         """
         Start a poller thread, until ``shutdown`` is called.
@@ -57,7 +65,8 @@ class Poller(Configuable):
                 func(*args, **kwargs)
                 self.shutdown_event.wait(timeout=self.interval_ms / 1000)
             # call func one last time before exit
-            func(*args, **kwargs)
+            if self.call_when_shutdown:
+                func(*args, **kwargs)
 
         self._thread = threading.Thread(target=_poll)
         self.shutdown_event.clear()

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -25,7 +25,8 @@ def test_poller(poller: Poller, capsys):
     poller.shutdown()
     poller.wait()
     captured = capsys.readouterr()
-    assert captured.out == "hello\nhello\n"
+    # One for the first time, one for 1.5 * interval_ms, one for last time
+    assert captured.out == "hello\nhello\nhello\n"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Call the function after shutdown event is set, avoid data loss

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently shutdown will shut down the poller directly, and we should collect all the data before shutting it down.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

see tests/test_poller.py

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Maintenance (no change in code, maintain the project's CI, docs, etc.)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.